### PR TITLE
Make Scalroid compatible with Kotlin 1.9.21+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now, this plugin is well developed and ready for official use.
 
 | Gradle          | Android Plugin    | Kotlin Plugin       | Scala (this plugin compiles) |
 |-----------------|-------------------|---------------------|------------------------------|
-| `7.6.2` ~ `8.4` | `7.4.0` ~ `8.1.3` | `1.7.20` ~ `1.9.20` | `2.10.x` ~ `3.x`             |
+| `7.6.2` ~ `8.5` | `7.4.0` ~ `8.2.2` | `1.7.20` ~ `1.9.22` | `2.10.x` ~ `3.x`             |
 
 * The Scala version fully supports the `ScalaPlugin` of gradle, see official documentation:
   https://docs.gradle.org/current/userguide/scala_plugin.html#sec:configure_zinc_compiler  
@@ -45,7 +45,7 @@ Now, this plugin is well developed and ready for official use.
       ```
     - Since the Gradle have bugs in `Scala incremental compilation` _~~and did not fixed in version **v7.x**: [#23202](https://github.com/gradle/gradle/issues/23202)~~_
       (but has been fixed in and after **v7.6.2**).
-      Nevertheless, Gradle **v8.0.1 ~ v8.4** is recommended, and scala incremental compilation works well.
+      Nevertheless, Gradle **v8.0.1 ~ v8.5** is recommended, and scala incremental compilation works well.
 
 ## Usage
 
@@ -81,9 +81,9 @@ git clone git@github.com:chenakam/scalroid.git buildSrc
 ```groovy
 // ...
 plugins {
-    id 'com.android.application' version '8.1.3' apply false
-    id 'com.android.library' version '8.1.3' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
+    id 'com.android.application' version '8.2.2' apply false
+    id 'com.android.library' version '8.2.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
 
     // TODO: if you have not clone the dir `buildSrc/`, you need to uncomment the `version` filed.
     id 'cash.bdo.scalroid' /*version '[1.6-gradle8,)'*/ apply false
@@ -108,7 +108,7 @@ plugins {
 
 android {
     scalroid {
-        scala.zincVersion = '1.8.0'
+        scala.zincVersion = '1.8.1'
 //        scalaCodeReferToKt = false // Take looks below
 //        ktCodeReferToScala = true
         // Whether to expand `R.jar`, so as to fix the problem of `R.id.xxx` marked red in Scala code.

--- a/src/main/groovy/cash/bdo/ScalaAndroidCompatPlugin.groovy
+++ b/src/main/groovy/cash/bdo/ScalaAndroidCompatPlugin.groovy
@@ -411,14 +411,14 @@ class ScalaAndroidCompatPlugin implements Plugin<Project> {
 
     // [evaluated] 表示是否在`project.afterEvaluate{}`中执行。
     private boolean resolveScalaSrcDirsToAndroidSourceSetsClosure(Project project, sourceSet, boolean evaluated) {
-        LOG.info "$NAME_PLUGIN ---> [resolveScalaSrcDirsToAndroidSourceSetsClosure]sourceSet.name:${sourceSet.name}, displayName:${sourceSet.displayName}"
+        LOG.info "$NAME_PLUGIN ---> [resolveScalaSrcDirsToAndroidSourceSetsClosure]sourceSet.name:${sourceSet.name}"
         LOG.info "$NAME_PLUGIN ---> [resolveScalaSrcDirsToAndroidSourceSetsClosure]sourceSet.extensions:${sourceSet.extensions}"
         //org.gradle.internal.extensibility.DefaultConvention
 
         // 对于不同的`sourceSet`，第一次肯定没有值。
         if (sourceSet.extensions.findByName('scala')) return false
 
-        final displayName = sourceSet.displayName //(String) InvokerHelper.invokeMethod(sourceSet, "getDisplayName", null)
+        final sourceSetName = sourceSet.name
 
         SourceDirectorySet scalaDirSet
         final gradleVersion = project.gradle.gradleVersion
@@ -426,18 +426,18 @@ class ScalaAndroidCompatPlugin implements Plugin<Project> {
 
         // TODO: 俩版本不能通用，会报错，只能在 publish 某版本时手动注释掉另一 case。
         if (verMajor >= 8) {
-            final scalaSourceSet = factory.newInstance(DefaultScalaSourceSet, displayName, factory)
+            final scalaSourceSet = factory.newInstance(DefaultScalaSourceSet, sourceSetName, factory)
             sourceSet.convention.plugins.put('scala', scalaSourceSet)
             scalaDirSet = scalaSourceSet.scala
 
             // TODO: 如果上面的不能用了，就启用下面的。
-//            final ScalaSourceDirectorySet scala = factory.newInstance(DefaultScalaSourceDirectorySet, factory.sourceDirectorySet('scala', "${displayName} Scala source"), dependencyFactory)
+//            final ScalaSourceDirectorySet scala = factory.newInstance(DefaultScalaSourceDirectorySet, factory.sourceDirectorySet('scala', "${sourceSetName} Scala source"), dependencyFactory)
 //            scala.filter.include('**/*.java', '**/*.scala')
 //            scalaDirSet = scala
         } else {
             //Convention sourceSetConvention = sourceSet.convention //(Convention) InvokerHelper.getProperty(sourceSet, "convention")
-            final scalaSourceSet = new DefaultScalaSourceSet(displayName, factory) {}
-//            final scalaSourceSet = factory.newInstance(DefaultScalaSourceSet, displayName, factory)
+            final scalaSourceSet = new DefaultScalaSourceSet(sourceSetName, factory) {}
+//            final scalaSourceSet = factory.newInstance(DefaultScalaSourceSet, sourceSetName, factory)
             // 这句`约定（convention）`的作用是添加：
             // sourceSets { main { scala.srcDirs += ['src/main/java'] } ...}
             sourceSet.convention.plugins.put('scala', scalaSourceSet)


### PR DESCRIPTION
Kotlin 1.9.21 removed source sets conventions registration for Gradle 8.2+

https://youtrack.jetbrains.com/issue/KT-63499

which causes Scalroid to fail because the `sourceSet.displayName` property no longer exists.